### PR TITLE
Set login status to "success" on reload if identity is found

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,7 @@ export function InternetIdentityProvider({
           setState((prevState) => ({
             ...prevState,
             identity,
+            loginStatus: "success",
           }));
         }
       }


### PR DESCRIPTION
I needed to know if the user was logged in or not. I had to change the hook to set the login status after reloading the page.