### PR TITLE
feat: expose getDelegation() 

### DIFF
--- a/src/context.type.ts
+++ b/src/context.type.ts
@@ -1,4 +1,5 @@
 import type { Identity } from "@icp-sdk/core/agent";
+import type { DelegationChain } from "@icp-sdk/core/identity";
 
 export type Status =
   | "initializing"
@@ -17,6 +18,19 @@ export type InternetIdentityContext = {
 
   /** Clears the identity from the state and local storage. Effectively "logs the user out". */
   clear: () => void;
+
+  /** Get the delegation chain from the current identity. Useful for accessing session expiration.
+   * Returns undefined if not authenticated or not a DelegationIdentity.
+   * @example
+   * ```ts
+   * const delegation = getDelegation();
+   * if (delegation) {
+   *   const expiration = delegation.delegations[0]?.delegation.expiration;
+   *   console.log('Session expires at:', new Date(Number(expiration / 1_000_000n)));
+   * }
+   * ```
+   */
+  getDelegation: () => DelegationChain | undefined;
 
   /** The status of the login process. Note: The login status is not affected when a stored
    * identity is loaded on mount. */


### PR DESCRIPTION
Exposes the delegation chain through a new `getDelegation()` function.

### Changes
- Added `getDelegation()` standalone function (similar to `getIdentity()`)
- Exposed `getDelegation()` through `useInternetIdentity` hook
- Updated TypeScript types and exports
- Added documentation with usage examples